### PR TITLE
Fix: Close() is called with canceled context

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func main() {
 		}
 
 		defer func() {
-			closeCtx, cancel := context.WithTimeout(ctx, config.RequestTimeout)
+			closeCtx, cancel := context.WithTimeout(context.Background(), config.RequestTimeout)
 			defer cancel()
 			_, _ = c.Close(closeCtx, resp)
 		}()


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/deployments-k8s/issues/954

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>