### PR TITLE
Fix use of nsc name in connection ignored

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/edwarnicke/debug v1.0.0
 	github.com/edwarnicke/grpcfd v0.1.0
 	github.com/edwarnicke/vpphelper v0.0.0-20210225052320-b4f1f1aff45d
-	github.com/google/uuid v1.1.2
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/networkservicemesh/api v0.5.1-0.20210618123026-2eb031b7db63
 	github.com/networkservicemesh/sdk v0.5.1-0.20210618123609-379badf2bfa7

--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -3,12 +3,10 @@ package imports
 
 import (
 	_ "context"
-	_ "fmt"
 	_ "github.com/antonfisher/nested-logrus-formatter"
 	_ "github.com/edwarnicke/debug"
 	_ "github.com/edwarnicke/grpcfd"
 	_ "github.com/edwarnicke/vpphelper"
-	_ "github.com/google/uuid"
 	_ "github.com/kelseyhightower/envconfig"
 	_ "github.com/networkservicemesh/api/pkg/api/networkservice"
 	_ "github.com/networkservicemesh/sdk-vpp/pkg/networkservice/connectioncontext"

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"os"
 	"os/signal"
@@ -31,7 +30,6 @@ import (
 	"github.com/edwarnicke/debug"
 	"github.com/edwarnicke/grpcfd"
 	"github.com/edwarnicke/vpphelper"
-	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
@@ -193,7 +191,6 @@ func main() {
 		}
 		request := &networkservice.NetworkServiceRequest{
 			Connection: &networkservice.Connection{
-				Id:             fmt.Sprintf("%v-%v", config.Name, uuid.New().String()),
 				NetworkService: u.NetworkService(),
 				Labels:         u.Labels(),
 			},


### PR DESCRIPTION

﻿This is a workaround for:
https://github.com/networkservicemesh/deployments-k8s/issues/1826

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
