### PR TITLE
[deployments-k8s#906] Decrease default token timeout to 10m

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ type Config struct {
 	DialTimeout      time.Duration `default:"5s" desc:"timeout to dial NSMgr" split_words:"true"`
 	RequestTimeout   time.Duration `default:"15s" desc:"timeout to request NSE" split_words:"true"`
 	ConnectTo        url.URL       `default:"unix:///var/lib/networkservicemesh/nsm.io.sock" desc:"url to connect to" split_words:"true"`
-	MaxTokenLifetime time.Duration `default:"24h" desc:"maximum lifetime of tokens" split_words:"true"`
+	MaxTokenLifetime time.Duration `default:"10m" desc:"maximum lifetime of tokens" split_words:"true"`
 	NetworkServices  []url.URL     `default:"" desc:"A list of Network Service Requests" split_words:"true"`
 }
 


### PR DESCRIPTION
## Description
Sets default token timeout to `10m`.

## Issue
networkservicemesh/deployments-k8s#906