### PR TITLE
[integration-k8s-kind#325] Use existing VPP instance if given

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,8 +35,8 @@ linters-settings:
   dupl:
     threshold: 150
   funlen:
-    Lines: 150
-    Statements: 70
+    Lines: 170
+    Statements: 80
   goconst:
     min-len: 2
     min-occurrences: 2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.0
 	github.com/edwarnicke/debug v1.0.0
 	github.com/edwarnicke/grpcfd v0.1.0
-	github.com/edwarnicke/vpphelper v0.0.0-20210225052320-b4f1f1aff45d
+	github.com/edwarnicke/vpphelper v0.0.0-20210512223648-f914b171f679
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/networkservicemesh/api v1.0.1-0.20210811070028-10403c0f20c8
 	github.com/networkservicemesh/sdk v0.5.1-0.20210823074050-b1370083e4e1

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/edwarnicke/log v1.0.0/go.mod h1:eWsQQlQ0IU5wHlJvyXFH3dS8s2g9GzN7JnXod
 github.com/edwarnicke/serialize v0.0.0-20200705214914-ebc43080eecf/go.mod h1:XvbCO/QGsl3X8RzjBMoRpkm54FIAZH5ChK2j+aox7pw=
 github.com/edwarnicke/serialize v1.0.7 h1:geX8vmyu8Ij2S5fFIXjy9gBDkKxXnrMIzMoDvV0Ddac=
 github.com/edwarnicke/serialize v1.0.7/go.mod h1:y79KgU2P7ALH/4j37uTSIdNavHFNttqN7pzO6Y8B2aw=
-github.com/edwarnicke/vpphelper v0.0.0-20210225052320-b4f1f1aff45d h1:Okg1uazbTBFvNTrWP5AbTLgG/xMsnZNIobxJYpyvyK8=
-github.com/edwarnicke/vpphelper v0.0.0-20210225052320-b4f1f1aff45d/go.mod h1:2KXgJqOUUCh9S4Zs2jAycQLqAcRGge3q+GXV2rN55ZQ=
+github.com/edwarnicke/vpphelper v0.0.0-20210512223648-f914b171f679 h1:TQGpOyiM1EZtGzKN5vwN5RLHc0Mskk9uh+aNsdynb1k=
+github.com/edwarnicke/vpphelper v0.0.0-20210512223648-f914b171f679/go.mod h1:2KXgJqOUUCh9S4Zs2jAycQLqAcRGge3q+GXV2rN55ZQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
## Description
Adds `VPPApiSocket` config parameter to use existing VPP instance instead of starting a new one.

## Issue link
networkservicemesh/integration-k8s-kind#325

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
