### PR TITLE
Add upstreamrefresh

### DIFF
--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -21,7 +21,7 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/recvfd"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/retry"
-	_ "github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/upstreamrefresh"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/awarenessgroups"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/log"

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/recvfd"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/retry"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/upstreamrefresh"
 	"github.com/networkservicemesh/sdk/pkg/tools/awarenessgroups"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -204,7 +204,7 @@ func main() {
 		client.WithHealClient(heal.NewClient(ctx)),
 		client.WithAdditionalFunctionality(
 			clientinfo.NewClient(),
-			metadata.NewClient(),
+			upstreamrefresh.NewClient(ctx),
 			up.NewClient(ctx, vppConn),
 			connectioncontext.NewClient(vppConn),
 			memif.NewClient(vppConn),


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/cmd-nse-vl3-vpp/issues/77

Deleted `metadata` - because we already have `metadata` in the client chain.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>