### PR TITLE
Remove recvfd from client's chain

### DIFF
--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -18,7 +18,6 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/clientinfo"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/excludedprefixes"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/heal"
-	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/recvfd"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/retry"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/upstreamrefresh"

--- a/main.go
+++ b/main.go
@@ -52,7 +52,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clientinfo"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/excludedprefixes"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/heal"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/recvfd"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/retry"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/upstreamrefresh"
@@ -219,7 +218,6 @@ func main() {
 			connectioncontext.NewClient(vppConn),
 			memif.NewClient(ctx, vppConn),
 			sendfd.NewClient(),
-			recvfd.NewClient(),
 			excludedprefixes.NewClient(excludedprefixes.WithAwarenessGroups(config.AwarenessGroups))),
 		client.WithDialTimeout(config.DialTimeout),
 		client.WithDialOptions(dialOptions...),


### PR DESCRIPTION
`recvfd` actually receives the same network namespace file descriptor from manager but with a different name